### PR TITLE
Throw a more explicit error

### DIFF
--- a/netsim/augment/topology.py
+++ b/netsim/augment/topology.py
@@ -83,7 +83,7 @@ def check_global_elements(topology: Box) -> None:
 
   for k in topology.keys():
     if not k in topo_elements:
-      common.error("Unknown top-level element %s, module %s not defined" % k,category=common.IncorrectValue,module="topology")
+      common.error("Unknown top-level element %s, module not defined" % k,category=common.IncorrectValue,module="topology")
 #
 # Find virtualization provider, set provider and defaults.provider to that value
 #


### PR DESCRIPTION
Hi, 
this is a **_very_** minor esthetic message which removes confusion and indicates clearly the absence of the declaration.

Currently:
```
vrfs:
  red:
  blue:

nodes:
  spine01:
    module: [ bgp]
```

`IncorrectValue in topology: Unknown top-level element vrfs`